### PR TITLE
add support for new `expanded` param in paged_articles (fix #15)

### DIFF
--- a/waybacknews/searchapi.py
+++ b/waybacknews/searchapi.py
@@ -118,11 +118,14 @@ class SearchApiClient:
                 more_pages = True
 
     def paged_articles(self, query: str, start_date: dt.datetime, end_date: dt.datetime,
-                       page_size: Optional[int] = 1000,  pagination_token: Optional[str] = None, **kwargs):
+                       page_size: Optional[int] = 1000,  expanded: bool = False,
+                       pagination_token: Optional[str] = None, **kwargs):
         """
         @return: one page of stories
         """
         params = {"q": "{} AND {}".format(query, self._date_query_clause(start_date, end_date))}
+        if expanded:
+            params['expanded'] = 1
         if pagination_token:
             params['resume'] = pagination_token
         params.update(kwargs)

--- a/waybacknews/tests/test_waybacknews.py
+++ b/waybacknews/tests/test_waybacknews.py
@@ -122,6 +122,19 @@ class TestMediaCloudCollection(TestCase):
         page2_urls = [s['url'] for s in page2]
         assert page1_url1 not in page2_urls  # verify pages don't overlap
 
+    def test_paged_expanded_articles(self):
+        query = "biden"
+        start_date = dt.datetime(2023, 11, 25)
+        end_date = dt.datetime(2023, 11, 26)
+        page1, next_token1 = self._api.paged_articles(query, start_date, end_date)
+        for s in page1:
+            assert 'text_content' not in s
+        page2, next_token2 = self._api.paged_articles(query, start_date, end_date,
+                                                      pagination_token=next_token1, expanded=True)
+        for s in page2:
+            assert 'text_content' in s
+
+
     def test_top_sources(self):
         results = self._api.top_sources("coronavirus", dt.datetime(2022, 3, 1), dt.datetime(2022, 4, 1))
         assert len(results) > 0


### PR DESCRIPTION
Very simple fix, which add support for the new `expanded` parameter now supported by to-be-release news-search-api version (https://github.com/mediacloud/news-search-api/pull/39).